### PR TITLE
issue #27 remove "undefined" from display name

### DIFF
--- a/ChumsApi/src/helpers/PersonHelper.ts
+++ b/ChumsApi/src/helpers/PersonHelper.ts
@@ -7,7 +7,7 @@ export class PersonHelper {
     }
 
     public static getDisplayName(person: Person) {
-        if (person?.name?.nick !== null && person?.name?.nick !== "") return person.name.first + " \"" + person.name.nick + "\" " + person.name.last;
+        if (person?.name?.nick !== null && person?.name?.nick !== "" && person?.name?.nick !== undefined) return person.name.first + " \"" + person.name.nick + "\" " + person.name.last;
         else return person.name.first + " " + person.name.last;
     }
 


### PR DESCRIPTION
PersonRepository.save is calling PersonHelper.getDisplayName(person) to set the displayName prior to updating the person record. The getDisplayName method is not handling the case where nick is undefined (since !== null will not capture undefined values). Added additional logic check for undefined values.